### PR TITLE
Add asset editing with categories

### DIFF
--- a/apps/asset-entry/index.html
+++ b/apps/asset-entry/index.html
@@ -6,6 +6,11 @@
     <div class="form-grid">
         <input type="text" id="asset-name" placeholder="Asset Name (e.g., Stocks)" required>
         <input type="number" id="asset-value" placeholder="Current Value ($)" step="0.01" required>
+        <select id="asset-category" required>
+            <option value="Cash">Cash</option>
+            <option value="Investment">Investment</option>
+            <option value="Retirement">Retirement</option>
+        </select>
     </div>
     <button type="submit">Add Asset</button>
 </form>

--- a/apps/asset-entry/script.js
+++ b/apps/asset-entry/script.js
@@ -1,6 +1,7 @@
 function setupAssetEntry() {
     const assetForm = document.getElementById('asset-form');
     const assetList = document.getElementById('asset-list');
+    const categories = ['Cash', 'Investment', 'Retirement'];
     let assets = loadAssets();
 
     function loadAssets() {
@@ -17,9 +18,35 @@ function setupAssetEntry() {
         assets.forEach(asset => {
             const item = document.createElement('div');
             item.className = 'asset-item';
+            item.dataset.id = asset.id;
             item.innerHTML = `
-                <span>${asset.name}: $${asset.value.toFixed(2)}</span>
-                <button class="delete-asset-btn" data-id="${asset.id}">Delete</button>
+                <div class="asset-item__header">
+                    <span>${asset.name} (${asset.category})</span>
+                    <div class="asset-item__header-actions">
+                        <button class="edit-asset-btn">Edit</button>
+                        <button class="delete-asset-btn">Delete</button>
+                    </div>
+                </div>
+                <p><strong>Value:</strong> $${asset.value.toFixed(2)}</p>
+                <form class="asset-item__edit-form" style="display:none">
+                    <input type="text" class="edit-asset-name" value="${asset.name}" required>
+                    <input type="number" class="edit-asset-value" value="${asset.value}" step="0.01" required>
+                    <select class="edit-asset-category">
+                        ${categories.map(c => `<option value="${c}" ${asset.category === c ? 'selected' : ''}>${c}</option>`).join('')}
+                    </select>
+                    <button type="submit" class="save-asset-btn">Save</button>
+                    <button type="button" class="cancel-edit-btn">Cancel</button>
+                </form>
+                <div class="asset-history">
+                    <h4>Update History</h4>
+                    <ul class="asset-history-list">
+                        ${asset.history.map(entry => `
+                            <li class="asset-history-item">
+                                ${new Date(entry.date).toLocaleDateString()}: ${entry.event} - $${entry.value.toFixed(2)}
+                            </li>
+                        `).join('')}
+                    </ul>
+                </div>
             `;
             assetList.appendChild(item);
         });
@@ -30,7 +57,16 @@ function setupAssetEntry() {
             e.preventDefault();
             const name = document.getElementById('asset-name').value;
             const value = parseFloat(document.getElementById('asset-value').value);
-            const newAsset = { id: Date.now(), name: name, value: value };
+            const category = document.getElementById('asset-category').value;
+            const now = new Date().toISOString();
+            const newAsset = {
+                id: Date.now(),
+                name: name,
+                value: value,
+                category: category,
+                lastUpdated: now,
+                history: [{ date: now, value: value, event: 'Asset Created' }]
+            };
             assets.push(newAsset);
             saveAssets(assets);
             renderAssets();
@@ -40,9 +76,65 @@ function setupAssetEntry() {
 
     if (assetList) {
         assetList.addEventListener('click', e => {
+            const item = e.target.closest('.asset-item');
+            if (!item) return;
+            const assetId = parseInt(item.dataset.id, 10);
+
             if (e.target.classList.contains('delete-asset-btn')) {
-                const id = parseInt(e.target.dataset.id, 10);
-                assets = assets.filter(a => a.id !== id);
+                e.stopPropagation();
+                if (confirm('Are you sure you want to delete this asset?')) {
+                    assets = assets.filter(a => a.id !== assetId);
+                    saveAssets(assets);
+                    renderAssets();
+                }
+                return;
+            }
+
+            if (e.target.classList.contains('edit-asset-btn')) {
+                e.stopPropagation();
+                const form = item.querySelector('.asset-item__edit-form');
+                if (form) {
+                    form.style.display = form.style.display === 'block' ? 'none' : 'block';
+                }
+                return;
+            }
+
+            if (e.target.classList.contains('cancel-edit-btn')) {
+                e.preventDefault();
+                const form = item.querySelector('.asset-item__edit-form');
+                if (form) {
+                    const asset = assets.find(a => a.id === assetId);
+                    if (asset) {
+                        form.querySelector('.edit-asset-name').value = asset.name;
+                        form.querySelector('.edit-asset-value').value = asset.value;
+                        form.querySelector('.edit-asset-category').value = asset.category;
+                    }
+                    form.style.display = 'none';
+                }
+                return;
+            }
+
+            const historyView = item.querySelector('.asset-history');
+            if (historyView) {
+                const isVisible = historyView.style.display === 'block';
+                historyView.style.display = isVisible ? 'none' : 'block';
+            }
+        });
+
+        assetList.addEventListener('submit', e => {
+            if (e.target.classList.contains('asset-item__edit-form')) {
+                e.preventDefault();
+                const item = e.target.closest('.asset-item');
+                const assetId = parseInt(item.dataset.id, 10);
+                const asset = assets.find(a => a.id === assetId);
+                if (!asset) return;
+                const now = new Date().toISOString();
+                const newValue = parseFloat(e.target.querySelector('.edit-asset-value').value);
+                asset.name = e.target.querySelector('.edit-asset-name').value;
+                asset.value = newValue;
+                asset.category = e.target.querySelector('.edit-asset-category').value;
+                asset.lastUpdated = now;
+                asset.history.push({ date: now, value: newValue, event: 'Asset Updated' });
                 saveAssets(assets);
                 renderAssets();
             }

--- a/apps/asset-entry/style.css
+++ b/apps/asset-entry/style.css
@@ -4,7 +4,22 @@
     font-family: "Courier New", monospace;
 }
 
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
 .asset-form input {
+    width: 100%;
+    padding: 10px;
+    border: 2px solid #000;
+    background: #fff;
+    box-sizing: border-box;
+}
+
+.asset-form select {
     width: 100%;
     padding: 10px;
     border: 2px solid #000;
@@ -38,6 +53,61 @@
     border: 2px solid #000;
     margin-bottom: 10px;
     background: #fff;
+}
+
+.asset-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.asset-item__header-actions button {
+    margin-left: 5px;
+    background: none;
+    border: 2px solid #000;
+    cursor: pointer;
+}
+
+.asset-item__edit-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.asset-item__edit-form input,
+.asset-item__edit-form select,
+.asset-item__edit-form button {
+    padding: 8px;
+    border: 2px solid #000;
+    background: #fff;
+}
+
+.asset-item__edit-form button {
+    cursor: pointer;
+}
+
+.asset-history {
+    display: none;
+    margin-top: 15px;
+    padding-top: 10px;
+    border-top: 1px solid #eee;
+}
+
+.asset-history-list {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.asset-history-item {
+    font-size: 14px;
+    padding: 5px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.asset-history-item:last-child {
+    border-bottom: none;
 }
 
 .asset-list {


### PR DESCRIPTION
## Summary
- allow selecting asset categories (Cash, Investment, Retirement)
- add edit capabilities for assets with history tracking
- style asset editor and list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6877ca405198832fae192430ae27190d