### PR TITLE
Add covered call tracker module

### DIFF
--- a/apps/covered-call-tracker/index.html
+++ b/apps/covered-call-tracker/index.html
@@ -1,0 +1,19 @@
+<div class="cc-header">
+    <h2>Covered Call Tracker</h2>
+</div>
+
+<form id="cc-position-form" class="cc-position-form">
+    <div class="form-grid">
+        <input type="text" id="cc-ticker" placeholder="Ticker" required>
+        <input type="number" id="cc-basis" placeholder="Total Basis ($)" step="0.01" required>
+        <input type="number" id="cc-shares" placeholder="Shares Held" required>
+        <input type="number" id="cc-strike" placeholder="Call Strike ($)" step="0.01">
+        <input type="number" id="cc-premium" placeholder="Call Premium ($)" step="0.01">
+        <input type="date" id="cc-expiry">
+    </div>
+    <button type="submit">Add Position</button>
+</form>
+
+<div id="cc-position-list" class="cc-position-list scrollable">
+    <!-- Positions will be dynamically added here -->
+</div>

--- a/apps/covered-call-tracker/script.js
+++ b/apps/covered-call-tracker/script.js
@@ -1,0 +1,154 @@
+function setupCoveredCallTracker() {
+    const positionForm = document.getElementById('cc-position-form');
+    const positionList = document.getElementById('cc-position-list');
+    let positions = loadPositions();
+
+    function loadPositions() {
+        return JSON.parse(localStorage.getItem('coveredCallPositions')) || [];
+    }
+
+    function savePositions(newPositions) {
+        localStorage.setItem('coveredCallPositions', JSON.stringify(newPositions));
+    }
+
+    function calculateMetrics(position) {
+        const totalPremium = position.calls.reduce((sum, c) => sum + parseFloat(c.premium), 0);
+        const adjustedBasis = (position.basis - totalPremium) / position.shares;
+        return { totalPremium, adjustedBasis };
+    }
+
+    function renderPositions() {
+        if (!positionList) return;
+        positionList.innerHTML = '';
+        positions.forEach(p => {
+            const metrics = calculateMetrics(p);
+            const item = document.createElement('div');
+            item.className = 'cc-position-item';
+            item.dataset.id = p.id;
+            item.innerHTML = `
+                <div class="cc-position-header">
+                    <span>${p.ticker} - ${p.shares} shares</span>
+                    <div>
+                        <button class="add-call-btn">Add Call</button>
+                        <button class="delete-position-btn">Delete</button>
+                    </div>
+                </div>
+                <p><strong>Basis:</strong> $${p.basis.toFixed(2)}</p>
+                <p><strong>Total Premium:</strong> $${metrics.totalPremium.toFixed(2)}</p>
+                <p><strong>Adjusted Cost/Share:</strong> $${metrics.adjustedBasis.toFixed(2)}</p>
+                <h4>Calls</h4>
+                <ul class="cc-call-list">
+                    ${p.calls.map(c => `
+                        <li data-call-id="${c.id}">
+                            $${c.strike} @ $${c.premium} exp ${c.expiry}
+                            <button class="delete-call-btn">Delete</button>
+                        </li>
+                    `).join('')}
+                </ul>
+                <form class="cc-add-call-form">
+                    <input type="number" class="cc-call-strike" placeholder="Strike" step="0.01" required>
+                    <input type="number" class="cc-call-premium" placeholder="Premium" step="0.01" required>
+                    <input type="date" class="cc-call-expiry" required>
+                    <button type="submit">Save</button>
+                    <button type="button" class="cancel-add-call-btn">Cancel</button>
+                </form>
+            `;
+            positionList.appendChild(item);
+        });
+    }
+
+    if (positionForm) {
+        positionForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const ticker = document.getElementById('cc-ticker').value.trim();
+            const basis = parseFloat(document.getElementById('cc-basis').value);
+            const shares = parseInt(document.getElementById('cc-shares').value, 10);
+            const strikeVal = document.getElementById('cc-strike').value;
+            const premiumVal = document.getElementById('cc-premium').value;
+            const expiryVal = document.getElementById('cc-expiry').value;
+            const newPosition = {
+                id: Date.now(),
+                ticker: ticker,
+                basis: basis,
+                shares: shares,
+                calls: []
+            };
+            if (strikeVal && premiumVal && expiryVal) {
+                newPosition.calls.push({
+                    id: Date.now() + 1,
+                    strike: parseFloat(strikeVal),
+                    premium: parseFloat(premiumVal),
+                    expiry: expiryVal
+                });
+            }
+            positions.push(newPosition);
+            savePositions(positions);
+            renderPositions();
+            positionForm.reset();
+        });
+    }
+
+    if (positionList) {
+        positionList.addEventListener('click', e => {
+            const item = e.target.closest('.cc-position-item');
+            if (!item) return;
+            const posId = parseInt(item.dataset.id, 10);
+            const position = positions.find(p => p.id === posId);
+            if (!position) return;
+
+            if (e.target.classList.contains('add-call-btn')) {
+                const form = item.querySelector('.cc-add-call-form');
+                if (form) {
+                    form.style.display = form.style.display === 'block' ? 'none' : 'block';
+                }
+                return;
+            }
+
+            if (e.target.classList.contains('cancel-add-call-btn')) {
+                const form = e.target.closest('.cc-add-call-form');
+                if (form) form.style.display = 'none';
+                return;
+            }
+
+            if (e.target.classList.contains('delete-position-btn')) {
+                if (confirm('Delete this position?')) {
+                    positions = positions.filter(p => p.id !== posId);
+                    savePositions(positions);
+                    renderPositions();
+                }
+                return;
+            }
+
+            if (e.target.classList.contains('delete-call-btn')) {
+                const callId = parseInt(e.target.parentElement.dataset.callId, 10);
+                position.calls = position.calls.filter(c => c.id !== callId);
+                savePositions(positions);
+                renderPositions();
+            }
+        });
+
+        positionList.addEventListener('submit', e => {
+            if (e.target.classList.contains('cc-add-call-form')) {
+                e.preventDefault();
+                const item = e.target.closest('.cc-position-item');
+                const posId = parseInt(item.dataset.id, 10);
+                const position = positions.find(p => p.id === posId);
+                if (!position) return;
+                position.calls.push({
+                    id: Date.now(),
+                    strike: parseFloat(e.target.querySelector('.cc-call-strike').value),
+                    premium: parseFloat(e.target.querySelector('.cc-call-premium').value),
+                    expiry: e.target.querySelector('.cc-call-expiry').value
+                });
+                savePositions(positions);
+                renderPositions();
+            }
+        });
+    }
+
+    renderPositions();
+}
+
+if (typeof window.setupCoveredCallTracker !== 'function') {
+    window.setupCoveredCallTracker = setupCoveredCallTracker;
+}

--- a/apps/covered-call-tracker/style.css
+++ b/apps/covered-call-tracker/style.css
@@ -1,0 +1,94 @@
+/* Covered Call Tracker Styles */
+.cc-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.cc-position-form {
+    margin-bottom: 20px;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.cc-position-form input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--surface-color);
+    box-sizing: border-box;
+}
+
+.cc-position-form button {
+    width: 100%;
+    padding: 10px;
+    background-color: var(--highlight-color);
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.cc-position-form button:hover {
+    background-color: var(--accent-color);
+    color: #fff;
+}
+
+.cc-position-item {
+    border: 1px solid var(--border-color);
+    padding: 15px;
+    margin-bottom: 10px;
+    border-radius: 4px;
+    background: var(--surface-color);
+}
+
+.cc-position-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.cc-call-list {
+    list-style-type: none;
+    padding-left: 0;
+    margin-bottom: 10px;
+}
+
+.cc-call-list li {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.cc-call-list li:last-child {
+    border-bottom: none;
+}
+
+.cc-add-call-form {
+    display: none;
+    margin-top: 10px;
+}
+
+.cc-add-call-form input {
+    width: 100%;
+    padding: 5px;
+    margin-bottom: 10px;
+    border: 1px solid var(--border-color);
+    box-sizing: border-box;
+}
+
+.cc-add-call-form button {
+    margin-right: 5px;
+}
+
+.cc-position-list {
+    max-height: 400px;
+    overflow-y: auto;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -49,6 +49,13 @@ document.addEventListener('DOMContentLoaded', () => {
             path: 'apps/expense-tracker/',
             setupFunction: 'setupExpenseTracker'
         },
+        {
+            id: 'covered-call-tracker',
+            title: 'Covered Calls',
+            icon: '&#128188;',
+            path: 'apps/covered-call-tracker/',
+            setupFunction: 'setupCoveredCallTracker'
+        },
         // {
         //     id: 'app2',
         //     title: 'App Two',


### PR DESCRIPTION
## Summary
- add new Covered Call Tracker app with forms for positions and call tracking
- style the new app
- register Covered Call Tracker in the app manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68781ba118d8832fb62a16a9f302e3fb