### PR TITLE
Fix JSON parsing errors for asset and debt loading

### DIFF
--- a/apps/asset-entry/script.js
+++ b/apps/asset-entry/script.js
@@ -15,7 +15,16 @@ function setupAssetEntry() {
     }
 
     function loadAssets() {
-        return JSON.parse(localStorage.getItem('assets')) || [];
+        const stored = localStorage.getItem('assets');
+        if (!stored) {
+            return [];
+        }
+        try {
+            return JSON.parse(stored);
+        } catch (e) {
+            console.error('Error parsing assets from localStorage', e);
+            return [];
+        }
     }
 
     function saveAssets(newAssets) {

--- a/apps/debt-tracker/script.js
+++ b/apps/debt-tracker/script.js
@@ -43,7 +43,16 @@ function setupDebtTracker(sharedData) {
 
     // Function to load debts from localStorage
     function loadDebts() {
-        return JSON.parse(localStorage.getItem('debts')) || [];
+        const stored = localStorage.getItem('debts');
+        if (!stored) {
+            return [];
+        }
+        try {
+            return JSON.parse(stored);
+        } catch (e) {
+            console.error('Error parsing debts from localStorage', e);
+            return [];
+        }
     }
 
     // Function to save debts to localStorage


### PR DESCRIPTION
## Summary
- add error handling around `JSON.parse` when loading assets
- add error handling around `JSON.parse` when loading debts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878246698c0832fa6e90ea0eda2d00f