### PR TITLE
Fix DOM element checks in asset and debt scripts

### DIFF
--- a/apps/asset-entry/script.js
+++ b/apps/asset-entry/script.js
@@ -8,6 +8,9 @@ function setupAssetEntry() {
 
     if (toggleAddAssetFormBtn) {
         toggleAddAssetFormBtn.addEventListener('click', () => {
+            if (!addAssetFormContainer) {
+                return;
+            }
             const isVisible = addAssetFormContainer.style.display === 'block';
             addAssetFormContainer.style.display = isVisible ? 'none' : 'block';
             toggleAddAssetFormBtn.textContent = isVisible ? '+ Add New Asset' : '− Close Form';
@@ -81,7 +84,9 @@ function setupAssetEntry() {
             saveAssets(assets);
             renderAssets();
             assetForm.reset();
-            addAssetFormContainer.style.display = 'none';
+            if (addAssetFormContainer) {
+                addAssetFormContainer.style.display = 'none';
+            }
             if (toggleAddAssetFormBtn) {
                 toggleAddAssetFormBtn.textContent = '+ Add New Asset';
             }

--- a/apps/debt-tracker/script.js
+++ b/apps/debt-tracker/script.js
@@ -11,6 +11,9 @@ function setupDebtTracker(sharedData) {
     // Toggle the "Add New Account" form
     if (toggleAddFormBtn) {
         toggleAddFormBtn.addEventListener('click', () => {
+            if (!addDebtFormContainer) {
+                return;
+            }
             const isVisible = addDebtFormContainer.style.display === 'block';
             addDebtFormContainer.style.display = isVisible ? 'none' : 'block';
             toggleAddFormBtn.textContent = isVisible ? '+ Add New Account' : '− Close Form';
@@ -36,8 +39,12 @@ function setupDebtTracker(sharedData) {
             saveDebts(debts);
             renderDebtAccounts();
             debtForm.reset();
-            addDebtFormContainer.style.display = 'none'; // Hide form after adding
-            toggleAddFormBtn.textContent = '+ Add New Account';
+            if (addDebtFormContainer) {
+                addDebtFormContainer.style.display = 'none'; // Hide form after adding
+            }
+            if (toggleAddFormBtn) {
+                toggleAddFormBtn.textContent = '+ Add New Account';
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- avoid errors if asset form container doesn't exist
- check debt form container before toggling or hiding form

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687824648e44832fa053903365c5a853