### PR TITLE
Display monthly balances table on Debt Tracker

### DIFF
--- a/apps/debt-tracker/style.css
+++ b/apps/debt-tracker/style.css
@@ -182,6 +182,19 @@
     margin-top: 10px;
 }
 
+.debt-account__monthly-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.debt-account__monthly-table th,
+.debt-account__monthly-table td {
+    border: 1px solid var(--border-color);
+    padding: 4px;
+    text-align: center;
+}
+
 .debt-account__monthly-list {
     list-style-type: none;
     padding-left: 0;


### PR DESCRIPTION
## Summary
- implement year-based month table generation
- show the current year's 12 months even when data is missing
- allocate updates to the selected month
- show balances for the account's most recent year

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687926ef7ff4832fa3cbd290fee78238