### PR TITLE
Load Chart.js dynamically for financial summary

### DIFF
--- a/apps/financial-summary/index.html
+++ b/apps/financial-summary/index.html
@@ -13,5 +13,3 @@
 <table id="summary-table" class="summary-table"></table>
 
 <canvas id="summary-chart" width="400" height="300"></canvas>
-
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- dynamically inject the Chart.js script before rendering the financial summary chart
- add graceful error handling that hides the canvas and shows a fallback message when Chart.js fails to load
- remove the static CDN Chart.js script tag from the financial summary HTML

## Testing
- No automated tests (project has no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8a053a47c832faffdff3998784d29