### PR TITLE
Add global scrollable utility class

### DIFF
--- a/apps/asset-tracker/style.css
+++ b/apps/asset-tracker/style.css
@@ -199,8 +199,3 @@
     border-bottom: none;
 }
 
-/* Allow sections marked as scrollable to scroll independently */
-.scrollable {
-    max-height: 400px;
-    overflow-y: auto;
-}

--- a/apps/debt-tracker/style.css
+++ b/apps/debt-tracker/style.css
@@ -210,8 +210,3 @@
     border-bottom: none;
 }
 
-/* Allow sections marked as scrollable to scroll independently */
-.scrollable {
-    max-height: 400px;
-    overflow-y: auto;
-}

--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,12 @@ body {
     text-transform: uppercase;
 }
 
+/* Utility classes */
+.scrollable {
+    max-height: 400px;
+    overflow-y: auto;
+}
+
 /* Modal Styles */
 .modal-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- add a reusable `.scrollable` utility in the shared stylesheet with the standard height and overflow settings
- remove per-app `.scrollable` definitions so individual components rely on the shared rule

## Testing
- not run (project has no `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_68c8a0481d8c832fbd78268f916c6119