### PR TITLE
Refactor module forms to use shared classes

### DIFF
--- a/apps/asset-tracker/index.html
+++ b/apps/asset-tracker/index.html
@@ -6,16 +6,16 @@
 <div id="add-asset-form-container" class="add-asset-form-container" style="display: none;">
     <form id="asset-form" class="asset-form">
         <div class="form-grid">
-            <input type="text" id="asset-name" placeholder="Account Name (e.g., Savings Account)" required>
-            <input type="number" id="asset-principal" placeholder="Current Value ($)" required step="0.01">
-            <select id="asset-category">
+            <input class="form-input" type="text" id="asset-name" placeholder="Account Name (e.g., Savings Account)" required>
+            <input class="form-input" type="number" id="asset-principal" placeholder="Current Value ($)" required step="0.01">
+            <select class="form-input" id="asset-category">
                 <option value="Cash">Cash</option>
                 <option value="Investment">Investment</option>
                 <option value="Retirement">Retirement</option>
                 <option value="Other">Other</option>
             </select>
         </div>
-        <button type="submit">Add Account</button>
+        <button class="button primary-button button-block" type="submit">Add Account</button>
     </form>
 </div>
 

--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -104,17 +104,17 @@ function setupAssetTracker(sharedData) {
                     </ul>
                 </div>
                 <form class="asset-account__edit-form" style="display:none">
-                    <input type="text" class="edit-asset-name" value="${asset.name}" required>
-                    <input type="number" class="edit-asset-principal" value="${asset.principal}" step="0.01" required>
-                    <input type="month" class="edit-asset-month" value="${new Date().toISOString().slice(0,7)}" required>
-                    <select class="edit-asset-category">
+                    <input class="form-input edit-asset-name" type="text" value="${asset.name}" required>
+                    <input class="form-input edit-asset-principal" type="number" value="${asset.principal}" step="0.01" required>
+                    <input class="form-input edit-asset-month" type="month" value="${new Date().toISOString().slice(0,7)}" required>
+                    <select class="form-input edit-asset-category">
                         <option value="Cash" ${asset.category === 'Cash' ? 'selected' : ''}>Cash</option>
                         <option value="Investment" ${asset.category === 'Investment' ? 'selected' : ''}>Investment</option>
                         <option value="Retirement" ${asset.category === 'Retirement' ? 'selected' : ''}>Retirement</option>
                         <option value="Other" ${asset.category === 'Other' ? 'selected' : ''}>Other</option>
                     </select>
-                    <button type="submit" class="save-asset-btn">Save</button>
-                    <button type="button" class="cancel-edit-btn">Cancel</button>
+                    <button class="button primary-button save-asset-btn" type="submit">Save</button>
+                    <button class="button secondary-button cancel-edit-btn" type="button">Cancel</button>
                 </form>
                 <div class="asset-account__history">
                     <h4>Update History</h4>

--- a/apps/asset-tracker/style.css
+++ b/apps/asset-tracker/style.css
@@ -28,38 +28,8 @@
     font-family: Arial, sans-serif;
 }
 
-.form-grid {
-    display: grid;
+.asset-form .form-grid {
     grid-template-columns: 1fr 1fr 1fr;
-    gap: 15px;
-    margin-bottom: 15px;
-}
-
-.asset-form input,
-.asset-form select {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--surface-color);
-    box-sizing: border-box; /* Important for padding */
-}
-
-.asset-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    color: #000;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 16px;
-    transition: background-color 0.2s;
-}
-
-.asset-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
 }
 
 .asset-divider {
@@ -136,18 +106,13 @@
     margin-top: 10px;
 }
 
-.asset-account__edit-form input,
-.asset-account__edit-form select,
-.asset-account__edit-form button {
+.asset-account__edit-form .form-input,
+.asset-account__edit-form .button {
     padding: 8px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    border-radius: 4px;
 }
 
-.asset-account__edit-form button {
-    cursor: pointer;
-    border-radius: 4px;
+.asset-account__edit-form .primary-button {
+    width: auto;
 }
 
 .asset-account--stale {

--- a/apps/budget-planner/index.html
+++ b/apps/budget-planner/index.html
@@ -4,10 +4,10 @@
 
 <form id="budget-form" class="budget-form">
     <div class="form-grid">
-        <input type="text" id="budget-category" placeholder="Category" required>
-        <input type="number" id="budget-amount" placeholder="Monthly Budget ($)" step="0.01" required>
+        <input class="form-input" type="text" id="budget-category" placeholder="Category" required>
+        <input class="form-input" type="number" id="budget-amount" placeholder="Monthly Budget ($)" step="0.01" required>
     </div>
-    <button type="submit">Add Budget</button>
+    <button class="button primary-button button-block" type="submit">Add Budget</button>
 </form>
 
 <div id="budget-list" class="budget-list scrollable">

--- a/apps/budget-planner/style.css
+++ b/apps/budget-planner/style.css
@@ -10,33 +10,8 @@
     margin-bottom: 20px;
 }
 
-.form-grid {
-    display: grid;
+.budget-form .form-grid {
     grid-template-columns: 1fr 1fr;
-    gap: 15px;
-    margin-bottom: 15px;
-}
-
-.budget-form input {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    box-sizing: border-box;
-}
-
-.budget-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    border: 1px solid var(--border-color);
-    cursor: pointer;
-    border-radius: 4px;
-}
-
-.budget-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
 }
 
 .budget-item {

--- a/apps/covered-call-tracker/index.html
+++ b/apps/covered-call-tracker/index.html
@@ -4,14 +4,14 @@
 
 <form id="cc-position-form" class="cc-position-form">
     <div class="form-grid">
-        <input type="text" id="cc-ticker" placeholder="Ticker" required>
-        <input type="number" id="cc-basis" placeholder="Total Basis ($)" step="0.01" required>
-        <input type="number" id="cc-shares" placeholder="Shares Held" required>
-        <input type="number" id="cc-strike" placeholder="Call Strike ($)" step="0.01">
-        <input type="number" id="cc-premium" placeholder="Call Premium ($)" step="0.01">
-        <input type="date" id="cc-expiry">
+        <input class="form-input" type="text" id="cc-ticker" placeholder="Ticker" required>
+        <input class="form-input" type="number" id="cc-basis" placeholder="Total Basis ($)" step="0.01" required>
+        <input class="form-input" type="number" id="cc-shares" placeholder="Shares Held" required>
+        <input class="form-input" type="number" id="cc-strike" placeholder="Call Strike ($)" step="0.01">
+        <input class="form-input" type="number" id="cc-premium" placeholder="Call Premium ($)" step="0.01">
+        <input class="form-input" type="date" id="cc-expiry">
     </div>
-    <button type="submit">Add Position</button>
+    <button class="button primary-button button-block" type="submit">Add Position</button>
 </form>
 
 <div id="cc-position-list" class="cc-position-list scrollable">

--- a/apps/covered-call-tracker/script.js
+++ b/apps/covered-call-tracker/script.js
@@ -53,11 +53,11 @@ function setupCoveredCallTracker() {
 
             const addCallForm = p.salePrice === undefined ? `
                 <form class="cc-add-call-form">
-                    <input type="number" class="cc-call-strike" placeholder="Strike" step="0.01" required>
-                    <input type="number" class="cc-call-premium" placeholder="Premium" step="0.01" required>
-                    <input type="date" class="cc-call-expiry" required>
-                    <button type="submit">Save</button>
-                    <button type="button" class="cancel-add-call-btn">Cancel</button>
+                    <input class="form-input cc-call-strike" type="number" placeholder="Strike" step="0.01" required>
+                    <input class="form-input cc-call-premium" type="number" placeholder="Premium" step="0.01" required>
+                    <input class="form-input cc-call-expiry" type="date" required>
+                    <button class="button primary-button" type="submit">Save</button>
+                    <button class="button secondary-button cancel-add-call-btn" type="button">Cancel</button>
                 </form>
             ` : '';
 

--- a/apps/covered-call-tracker/style.css
+++ b/apps/covered-call-tracker/style.css
@@ -10,33 +10,8 @@
     margin-bottom: 20px;
 }
 
-.form-grid {
-    display: grid;
+.cc-position-form .form-grid {
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 15px;
-    margin-bottom: 15px;
-}
-
-.cc-position-form input {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    box-sizing: border-box;
-}
-
-.cc-position-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    border: 1px solid var(--border-color);
-    cursor: pointer;
-    border-radius: 4px;
-}
-
-.cc-position-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
 }
 
 .cc-position-item {
@@ -76,15 +51,12 @@
     margin-top: 10px;
 }
 
-.cc-add-call-form input {
-    width: 100%;
+.cc-add-call-form .form-input {
     padding: 5px;
     margin-bottom: 10px;
-    border: 1px solid var(--border-color);
-    box-sizing: border-box;
 }
 
-.cc-add-call-form button {
+.cc-add-call-form .button {
     margin-right: 5px;
 }
 

--- a/apps/debt-tracker/index.html
+++ b/apps/debt-tracker/index.html
@@ -6,12 +6,12 @@
 <div id="add-debt-form-container" class="add-debt-form-container" style="display: none;">
     <form id="debt-form" class="debt-form">
         <div class="form-grid">
-            <input type="text" id="debt-name" placeholder="Account Name (e.g., Car Loan)" required>
-            <input type="number" id="debt-principal" placeholder="Current Principal ($)" required step="0.01">
-            <input type="number" id="debt-payment" placeholder="Monthly Payment ($)" required step="0.01">
-            <input type="number" id="debt-rate" placeholder="Interest Rate (%)" required step="0.01">
+            <input class="form-input" type="text" id="debt-name" placeholder="Account Name (e.g., Car Loan)" required>
+            <input class="form-input" type="number" id="debt-principal" placeholder="Current Principal ($)" required step="0.01">
+            <input class="form-input" type="number" id="debt-payment" placeholder="Monthly Payment ($)" required step="0.01">
+            <input class="form-input" type="number" id="debt-rate" placeholder="Interest Rate (%)" required step="0.01">
         </div>
-        <button type="submit">Add Account</button>
+        <button class="button primary-button button-block" type="submit">Add Account</button>
     </form>
 </div>
 

--- a/apps/debt-tracker/script.js
+++ b/apps/debt-tracker/script.js
@@ -166,13 +166,13 @@ function setupDebtTracker(sharedData) {
                     </table>
                 </div>
                 <form class="debt-account__edit-form" style="display:none">
-                    <input type="text" class="edit-debt-name" value="${debt.name}" required>
-                    <input type="number" class="edit-debt-principal" value="${debt.principal}" step="0.01" required>
-                    <input type="month" class="edit-debt-month" value="${new Date().toISOString().slice(0,7)}" required>
-                    <input type="number" class="edit-debt-payment" value="${debt.payment}" step="0.01" required>
-                    <input type="number" class="edit-debt-rate" value="${debt.rate}" step="0.01" required>
-                    <button type="submit" class="save-debt-btn">Save</button>
-                    <button type="button" class="cancel-edit-btn">Cancel</button>
+                    <input class="form-input edit-debt-name" type="text" value="${debt.name}" required>
+                    <input class="form-input edit-debt-principal" type="number" value="${debt.principal}" step="0.01" required>
+                    <input class="form-input edit-debt-month" type="month" value="${new Date().toISOString().slice(0,7)}" required>
+                    <input class="form-input edit-debt-payment" type="number" value="${debt.payment}" step="0.01" required>
+                    <input class="form-input edit-debt-rate" type="number" value="${debt.rate}" step="0.01" required>
+                    <button class="button primary-button save-debt-btn" type="submit">Save</button>
+                    <button class="button secondary-button cancel-edit-btn" type="button">Cancel</button>
                 </form>
                 <div class="debt-account__history">
                     <h4>Update History</h4>

--- a/apps/debt-tracker/style.css
+++ b/apps/debt-tracker/style.css
@@ -28,37 +28,8 @@
     font-family: Arial, sans-serif;
 }
 
-.form-grid {
-    display: grid;
+.debt-form .form-grid {
     grid-template-columns: 1fr 1fr;
-    gap: 15px;
-    margin-bottom: 15px;
-}
-
-.debt-form input {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--surface-color);
-    box-sizing: border-box; /* Important for padding */
-}
-
-.debt-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    color: #000;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 16px;
-    transition: background-color 0.2s;
-}
-
-.debt-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
 }
 
 .debt-divider {
@@ -135,17 +106,13 @@
     margin-top: 10px;
 }
 
-.debt-account__edit-form input,
-.debt-account__edit-form button {
+.debt-account__edit-form .form-input,
+.debt-account__edit-form .button {
     padding: 8px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    border-radius: 4px;
 }
 
-.debt-account__edit-form button {
-    cursor: pointer;
-    border-radius: 4px;
+.debt-account__edit-form .primary-button {
+    width: auto;
 }
 
 .debt-account--stale {

--- a/apps/expense-tracker/index.html
+++ b/apps/expense-tracker/index.html
@@ -4,16 +4,16 @@
 
 <form id="expense-form" class="expense-form">
     <div class="form-grid">
-        <input type="text" id="expense-desc" placeholder="Description" required>
-        <input type="number" id="expense-amount" placeholder="Amount ($)" step="0.01" required>
-        <select id="expense-category">
+        <input class="form-input" type="text" id="expense-desc" placeholder="Description" required>
+        <input class="form-input" type="number" id="expense-amount" placeholder="Amount ($)" step="0.01" required>
+        <select class="form-input" id="expense-category">
             <option value="General">General</option>
             <option value="Food">Food</option>
             <option value="Utilities">Utilities</option>
             <option value="Entertainment">Entertainment</option>
         </select>
     </div>
-    <button type="submit">Add Expense</button>
+    <button class="button primary-button button-block" type="submit">Add Expense</button>
 </form>
 
 <div id="expense-list" class="expense-list scrollable">

--- a/apps/expense-tracker/style.css
+++ b/apps/expense-tracker/style.css
@@ -7,34 +7,8 @@
     margin-bottom: 20px;
 }
 
-.form-grid {
-    display: grid;
+.expense-form .form-grid {
     grid-template-columns: 1fr 1fr 1fr;
-    gap: 15px;
-    margin-bottom: 15px;
-}
-
-.expense-form input,
-.expense-form select {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    box-sizing: border-box;
-}
-
-.expense-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    border: 1px solid var(--border-color);
-    cursor: pointer;
-    border-radius: 4px;
-}
-
-.expense-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
 }
 
 .expense-item {

--- a/apps/savings-goal/index.html
+++ b/apps/savings-goal/index.html
@@ -3,13 +3,13 @@
 </div>
 
 <form id="goal-form" class="goal-form">
-    <input type="number" id="goal-amount" placeholder="Goal Amount ($)" step="0.01" required>
-    <button type="submit">Set Goal</button>
+    <input class="form-input" type="number" id="goal-amount" placeholder="Goal Amount ($)" step="0.01" required>
+    <button class="button primary-button button-block" type="submit">Set Goal</button>
 </form>
 
 <form id="contribution-form" class="contribution-form" style="display:none;">
-    <input type="number" id="contribution-amount" placeholder="Add Contribution ($)" step="0.01" required>
-    <button type="submit">Add</button>
+    <input class="form-input" type="number" id="contribution-amount" placeholder="Add Contribution ($)" step="0.01" required>
+    <button class="button primary-button button-block" type="submit">Add</button>
 </form>
 
 <div id="goal-progress" class="goal-progress"></div>

--- a/apps/savings-goal/style.css
+++ b/apps/savings-goal/style.css
@@ -8,30 +8,6 @@
     margin-bottom: 15px;
 }
 
-.goal-form input,
-.contribution-form input {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--border-color);
-    background: var(--surface-color);
-    box-sizing: border-box;
-}
-
-.goal-form button,
-.contribution-form button {
-    width: 100%;
-    padding: 10px;
-    background-color: var(--highlight-color);
-    border: 1px solid var(--border-color);
-    cursor: pointer;
-    border-radius: 4px;
-}
-
-.goal-form button:hover,
-.contribution-form button:hover {
-    background-color: var(--accent-color);
-    color: #fff;
-}
 
 .goal-progress {
     padding: 10px;

--- a/css/style.css
+++ b/css/style.css
@@ -101,3 +101,59 @@ body {
     font-weight: bold;
     cursor: pointer;
 }
+
+/* Shared form styles */
+.form-grid {
+    display: grid;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.form-input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--surface-color);
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.button {
+    display: inline-block;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--surface-color);
+    color: #000;
+    cursor: pointer;
+    font-size: 16px;
+    text-align: center;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.button:hover {
+    background-color: var(--highlight-color);
+}
+
+.button-block {
+    display: block;
+    width: 100%;
+}
+
+.primary-button {
+    background-color: var(--highlight-color);
+    color: #000;
+}
+
+.primary-button:hover {
+    background-color: var(--accent-color);
+    color: #fff;
+}
+
+.secondary-button {
+    background-color: var(--surface-color);
+}
+
+.secondary-button:hover {
+    background-color: var(--highlight-color);
+}


### PR DESCRIPTION
## Summary
- add shared form grid, input, and button classes to the global stylesheet
- update app-level styles to rely on the shared classes while keeping layout overrides
- apply the new classes to each app's form markup and script-generated controls

## Testing
- not run (project has no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8a05bfa40832fb1587fd0f5612da6