### PR TITLE
Use shared storage helpers for localStorage data

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -1,3 +1,5 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 // --- ASSET TRACKER LOGIC ---
 function setupAssetTracker(sharedData) {
     console.log('Setting up Asset Tracker...');
@@ -51,21 +53,12 @@ function setupAssetTracker(sharedData) {
 
     // Function to load assets from localStorage
     function loadAssets() {
-        const stored = localStorage.getItem('assets');
-        if (!stored) {
-            return [];
-        }
-        try {
-            return JSON.parse(stored);
-        } catch (e) {
-            console.error('Error parsing assets from localStorage', e);
-            return [];
-        }
+        return loadJSON('assets', []);
     }
 
     // Function to save assets to localStorage
     function saveAssets(assetsToSave) {
-        localStorage.setItem('assets', JSON.stringify(assetsToSave));
+        saveJSON('assets', assetsToSave);
     }
 
     // Function to render the asset accounts

--- a/apps/budget-planner/script.js
+++ b/apps/budget-planner/script.js
@@ -1,14 +1,16 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 function setupBudgetPlanner() {
     const budgetForm = document.getElementById('budget-form');
     const budgetList = document.getElementById('budget-list');
     let budgets = loadBudgets();
 
     function loadBudgets() {
-        return JSON.parse(localStorage.getItem('budgets')) || [];
+        return loadJSON('budgets', []);
     }
 
     function saveBudgets(newBudgets) {
-        localStorage.setItem('budgets', JSON.stringify(newBudgets));
+        saveJSON('budgets', newBudgets);
     }
 
     function renderBudgets() {

--- a/apps/covered-call-tracker/script.js
+++ b/apps/covered-call-tracker/script.js
@@ -1,14 +1,16 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 function setupCoveredCallTracker() {
     const positionForm = document.getElementById('cc-position-form');
     const positionList = document.getElementById('cc-position-list');
     let positions = loadPositions();
 
     function loadPositions() {
-        return JSON.parse(localStorage.getItem('coveredCallPositions')) || [];
+        return loadJSON('coveredCallPositions', []);
     }
 
     function savePositions(newPositions) {
-        localStorage.setItem('coveredCallPositions', JSON.stringify(newPositions));
+        saveJSON('coveredCallPositions', newPositions);
     }
 
     function calculateMetrics(position) {

--- a/apps/debt-tracker/script.js
+++ b/apps/debt-tracker/script.js
@@ -1,3 +1,5 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 // --- DEBT TRACKER LOGIC ---
 function setupDebtTracker(sharedData) {
     console.log('Setting up Debt Tracker...');
@@ -52,21 +54,12 @@ function setupDebtTracker(sharedData) {
 
     // Function to load debts from localStorage
     function loadDebts() {
-        const stored = localStorage.getItem('debts');
-        if (!stored) {
-            return [];
-        }
-        try {
-            return JSON.parse(stored);
-        } catch (e) {
-            console.error('Error parsing debts from localStorage', e);
-            return [];
-        }
+        return loadJSON('debts', []);
     }
 
     // Function to save debts to localStorage
     function saveDebts(debtsToSave) {
-        localStorage.setItem('debts', JSON.stringify(debtsToSave));
+        saveJSON('debts', debtsToSave);
     }
 
     // Function to calculate debt metrics

--- a/apps/expense-tracker/script.js
+++ b/apps/expense-tracker/script.js
@@ -1,14 +1,16 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 function setupExpenseTracker() {
     const expenseForm = document.getElementById('expense-form');
     const expenseList = document.getElementById('expense-list');
     let expenses = loadExpenses();
 
     function loadExpenses() {
-        return JSON.parse(localStorage.getItem('expenses')) || [];
+        return loadJSON('expenses', []);
     }
 
     function saveExpenses(data) {
-        localStorage.setItem('expenses', JSON.stringify(data));
+        saveJSON('expenses', data);
     }
 
     function renderExpenses() {

--- a/apps/financial-summary/script.js
+++ b/apps/financial-summary/script.js
@@ -1,6 +1,8 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 function setupFinancialSummary() {
-    const assets = JSON.parse(localStorage.getItem('assets')) || [];
-    const debts = JSON.parse(localStorage.getItem('debts')) || [];
+    const assets = loadJSON('assets', []);
+    const debts = loadJSON('debts', []);
 
     const totalAssets = assets.reduce((sum, a) => sum + parseFloat(a.principal || a.value || 0), 0);
     const totalDebt = debts.reduce((sum, d) => sum + parseFloat(d.principal || 0), 0);
@@ -11,7 +13,7 @@ function setupFinancialSummary() {
     document.getElementById('net-worth').textContent = `Net Worth: $${netWorth.toFixed(2)}`;
 
     const currentMonth = new Date().toISOString().slice(0, 7);
-    let snapshots = JSON.parse(localStorage.getItem('financialSnapshots')) || [];
+    let snapshots = loadJSON('financialSnapshots', []);
     const existing = snapshots.find(s => s.month === currentMonth);
     if (existing) {
         existing.totalAssets = totalAssets;
@@ -19,7 +21,7 @@ function setupFinancialSummary() {
     } else {
         snapshots.push({ month: currentMonth, totalAssets, totalDebt });
     }
-    localStorage.setItem('financialSnapshots', JSON.stringify(snapshots));
+    saveJSON('financialSnapshots', snapshots);
 
     let assetChange = 'N/A';
     let debtChange = 'N/A';

--- a/apps/savings-goal/script.js
+++ b/apps/savings-goal/script.js
@@ -1,3 +1,5 @@
+import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+
 function setupSavingsGoal() {
     const goalForm = document.getElementById('goal-form');
     const contributionForm = document.getElementById('contribution-form');
@@ -5,11 +7,11 @@ function setupSavingsGoal() {
     let goalData = loadGoal();
 
     function loadGoal() {
-        return JSON.parse(localStorage.getItem('savingsGoal')) || { goal: 0, saved: 0 };
+        return loadJSON('savingsGoal', { goal: 0, saved: 0 });
     }
 
     function saveGoal(data) {
-        localStorage.setItem('savingsGoal', JSON.stringify(data));
+        saveJSON('savingsGoal', data);
     }
 
     function renderProgress() {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
         </div>
     </div>
 
-    <script src="js/script.js"></script>
+    <script type="module" src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,3 +1,5 @@
+import { loadJSON, saveJSON } from './utils/storage.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const appContainer = document.getElementById('app-container');
     const modalOverlay = document.getElementById('modal-overlay');
@@ -78,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const script = document.createElement('script');
             script.id = `script-${app.id}`;
             script.defer = true;
+            script.type = 'module';
 
             // IMPORTANT: Set onload BEFORE src to prevent race conditions.
             script.onload = () => {
@@ -120,21 +123,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveTileOrder = () => {
         const ids = Array.from(appContainer.querySelectorAll('.app-tile'))
             .map(tile => tile.dataset.id);
-        localStorage.setItem('appOrder', JSON.stringify(ids));
+        saveJSON('appOrder', ids);
     };
 
     const loadTileOrder = () => {
-        const stored = localStorage.getItem('appOrder');
-        if (!stored) return;
-        try {
-            const ids = JSON.parse(stored);
-            ids.forEach(id => {
-                const tile = appContainer.querySelector(`[data-id="${id}"]`);
-                if (tile) appContainer.appendChild(tile);
-            });
-        } catch (e) {
-            console.error('Failed to parse app order', e);
+        const ids = loadJSON('appOrder', []);
+        if (!Array.isArray(ids)) {
+            return;
         }
+        ids.forEach(id => {
+            const tile = appContainer.querySelector(`[data-id="${id}"]`);
+            if (tile) appContainer.appendChild(tile);
+        });
     };
 
     const getDragAfterElement = (container, y) => {

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,0 +1,30 @@
+export function loadJSON(key, fallback = null) {
+    if (typeof localStorage === 'undefined') {
+        return fallback;
+    }
+
+    const stored = localStorage.getItem(key);
+    if (stored === null) {
+        return fallback;
+    }
+
+    try {
+        const parsed = JSON.parse(stored);
+        return parsed ?? fallback;
+    } catch (error) {
+        console.error(`Failed to parse JSON from localStorage for key "${key}"`, error);
+        return fallback;
+    }
+}
+
+export function saveJSON(key, value) {
+    if (typeof localStorage === 'undefined') {
+        return;
+    }
+
+    try {
+        localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+        console.error(`Failed to save JSON to localStorage for key "${key}"`, error);
+    }
+}


### PR DESCRIPTION
## Summary
- add js/utils/storage.js with shared loadJSON and saveJSON helpers that guard JSON parsing
- update the launcher and all app scripts to import the helpers and remove direct JSON.parse/localStorage calls
- load the main launcher and app scripts as ES modules so they can share the storage utilities

## Testing
- npm test *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a057a85c832f812c1a0a062abb08