### PR TITLE
Remove unused parameter from asset tracker setup

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -1,7 +1,7 @@
 import { loadJSON, saveJSON } from '../../js/utils/storage.js';
 
 // --- ASSET TRACKER LOGIC ---
-function setupAssetTracker(sharedData) {
+function setupAssetTracker() {
     console.log('Setting up Asset Tracker...');
     const assetForm = document.getElementById('asset-form');
     const assetAccountsContainer = document.getElementById('asset-accounts-container');


### PR DESCRIPTION
## Summary
- remove the unused `sharedData` parameter from `setupAssetTracker`
- keep the asset tracker initializer aligned with its usage across the app loader

## Testing
- not run (project does not include a package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8af545c38832fb971f094ec556bdd