### PR TITLE
Ensure asset principal persistence and migrate legacy data

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -1,4 +1,4 @@
-import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+import { ensureAssetsHavePrincipal, loadJSON, saveJSON } from '../../js/utils/storage.js';
 
 // --- ASSET TRACKER LOGIC ---
 function setupAssetTracker(sharedData) {
@@ -53,12 +53,19 @@ function setupAssetTracker(sharedData) {
 
     // Function to load assets from localStorage
     function loadAssets() {
-        return loadJSON('assets', []);
+        const storedAssets = loadJSON('assets', []);
+        const { assets: normalizedAssets, migrated } = ensureAssetsHavePrincipal(storedAssets);
+        if (migrated) {
+            saveJSON('assets', normalizedAssets);
+        }
+        return normalizedAssets;
     }
 
     // Function to save assets to localStorage
     function saveAssets(assetsToSave) {
-        saveJSON('assets', assetsToSave);
+        const { assets: normalizedAssets } = ensureAssetsHavePrincipal(assetsToSave);
+        assets = normalizedAssets;
+        saveJSON('assets', normalizedAssets);
     }
 
     // Function to render the asset accounts

--- a/apps/financial-summary/script.js
+++ b/apps/financial-summary/script.js
@@ -1,10 +1,17 @@
-import { loadJSON, saveJSON } from '../../js/utils/storage.js';
+import { ensureAssetsHavePrincipal, loadJSON, saveJSON } from '../../js/utils/storage.js';
 
 function setupFinancialSummary() {
-    const assets = loadJSON('assets', []);
+    const rawAssets = loadJSON('assets', []);
+    const { assets, migrated } = ensureAssetsHavePrincipal(rawAssets);
+    if (migrated) {
+        saveJSON('assets', assets);
+    }
     const debts = loadJSON('debts', []);
 
-    const totalAssets = assets.reduce((sum, a) => sum + parseFloat(a.principal || a.value || 0), 0);
+    const totalAssets = assets.reduce((sum, asset) => {
+        const principal = typeof asset.principal === 'number' ? asset.principal : parseFloat(asset.principal);
+        return sum + (Number.isFinite(principal) ? principal : 0);
+    }, 0);
     const totalDebt = debts.reduce((sum, d) => sum + parseFloat(d.principal || 0), 0);
     const netWorth = totalAssets - totalDebt;
 

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -28,3 +28,97 @@ export function saveJSON(key, value) {
         console.error(`Failed to save JSON to localStorage for key "${key}"`, error);
     }
 }
+
+export function ensureAssetsHavePrincipal(records) {
+    if (!Array.isArray(records)) {
+        return { assets: [], migrated: false };
+    }
+
+    let migrated = false;
+
+    const normalizedAssets = records.map(asset => {
+        if (!asset || typeof asset !== 'object') {
+            return asset;
+        }
+
+        const normalizedAsset = { ...asset };
+        let assetChanged = false;
+
+        const rawPrincipal = normalizedAsset.principal !== undefined ? normalizedAsset.principal : normalizedAsset.value;
+        const parsedPrincipal = typeof rawPrincipal === 'number' ? rawPrincipal : parseFloat(rawPrincipal);
+        const normalizedPrincipal = Number.isFinite(parsedPrincipal) ? parsedPrincipal : 0;
+
+        if (normalizedAsset.principal !== normalizedPrincipal) {
+            normalizedAsset.principal = normalizedPrincipal;
+            assetChanged = true;
+        }
+
+        if ('value' in normalizedAsset) {
+            delete normalizedAsset.value;
+            assetChanged = true;
+        }
+
+        if (Array.isArray(normalizedAsset.history)) {
+            let historyChanged = false;
+            const normalizedHistory = normalizedAsset.history.map(entry => {
+                if (!entry || typeof entry !== 'object') {
+                    return entry;
+                }
+
+                const normalizedEntry = { ...entry };
+                let entryChanged = false;
+
+                const entryRawPrincipal = normalizedEntry.principal !== undefined ? normalizedEntry.principal : normalizedEntry.value;
+                const entryParsedPrincipal = typeof entryRawPrincipal === 'number' ? entryRawPrincipal : parseFloat(entryRawPrincipal);
+                const entryPrincipal = Number.isFinite(entryParsedPrincipal) ? entryParsedPrincipal : 0;
+
+                if (normalizedEntry.principal !== entryPrincipal) {
+                    normalizedEntry.principal = entryPrincipal;
+                    entryChanged = true;
+                }
+
+                if ('value' in normalizedEntry) {
+                    delete normalizedEntry.value;
+                    entryChanged = true;
+                }
+
+                if (entryChanged) {
+                    historyChanged = true;
+                }
+
+                return entryChanged ? normalizedEntry : entry;
+            });
+
+            if (historyChanged) {
+                normalizedAsset.history = normalizedHistory;
+                assetChanged = true;
+            }
+        }
+
+        if (normalizedAsset.monthlyBalances && typeof normalizedAsset.monthlyBalances === 'object' && !Array.isArray(normalizedAsset.monthlyBalances)) {
+            const normalizedBalances = {};
+            let balancesChanged = false;
+            for (const [month, value] of Object.entries(normalizedAsset.monthlyBalances)) {
+                const parsedBalance = typeof value === 'number' ? value : parseFloat(value);
+                const numericBalance = Number.isFinite(parsedBalance) ? parsedBalance : 0;
+                normalizedBalances[month] = numericBalance;
+                if (numericBalance !== value) {
+                    balancesChanged = true;
+                }
+            }
+
+            if (balancesChanged) {
+                normalizedAsset.monthlyBalances = normalizedBalances;
+                assetChanged = true;
+            }
+        }
+
+        if (assetChanged) {
+            migrated = true;
+        }
+
+        return normalizedAsset;
+    });
+
+    return { assets: normalizedAssets, migrated };
+}


### PR DESCRIPTION
## Summary
- add a shared helper to normalize asset records and migrate legacy `value` fields to `principal`
- update the asset tracker to sanitize stored data on load/save so every asset persists a principal amount
- rely on `principal` in the financial summary while triggering migration when assets are loaded

## Testing
- not run (project has no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8af5db044832f814fb37abaaa9afa