### PR TITLE
Load asset tracker module via dynamic import

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -1,7 +1,7 @@
 import { loadJSON, saveJSON } from '../../js/utils/storage.js';
 
 // --- ASSET TRACKER LOGIC ---
-function setupAssetTracker(sharedData) {
+export function setupAssetTracker(sharedData) {
     console.log('Setting up Asset Tracker...');
     const assetForm = document.getElementById('asset-form');
     const assetAccountsContainer = document.getElementById('asset-accounts-container');
@@ -213,10 +213,5 @@ function setupAssetTracker(sharedData) {
 
     // Initial render
     renderAssetAccounts();
-}
-
-// Check if the function is already defined to avoid re-running on script load
-if (typeof window.setupAssetTracker !== 'function') {
-    window.setupAssetTracker = setupAssetTracker;
 }
 


### PR DESCRIPTION
## Summary
- export the asset tracker setup logic directly from its module and drop the window registration guard
- replace manual script-tag injection with a dynamic import that invokes the module's exported setup function

## Testing
- Not run (project has no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8af5ac7fc832f8cb4b88d93850542