### PR TITLE
Refactor asset history list into table

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -122,13 +122,24 @@ export function setupAssetTracker(sharedData) {
                 </form>
                 <div class="asset-account__history">
                     <h4>Update History</h4>
-                    <ul class="asset-account__history-list">
-                        ${asset.history.map(entry => `
-                            <li class="asset-account__history-item">
-                                ${new Date(entry.date).toLocaleDateString()}: ${entry.event} - $${entry.principal.toFixed(2)}
-                            </li>
-                        `).join('')}
-                    </ul>
+                    <table class="asset-account__history-table">
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Event</th>
+                                <th>Principal</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${asset.history.map(entry => `
+                                <tr>
+                                    <td>${new Date(entry.date).toLocaleDateString()}</td>
+                                    <td>${entry.event}</td>
+                                    <td>$${entry.principal.toFixed(2)}</td>
+                                </tr>
+                            `).join('')}
+                        </tbody>
+                    </table>
                 </div>
             `;
             assetAccountsContainer.appendChild(accountCard);

--- a/apps/asset-tracker/style.css
+++ b/apps/asset-tracker/style.css
@@ -118,19 +118,21 @@
     margin-bottom: 10px;
 }
 
-.asset-account__history-list {
-    list-style-type: none;
-    padding-left: 0;
-}
-
-.asset-account__history-item {
+.asset-account__history-table {
+    width: 100%;
+    border-collapse: collapse;
     font-size: 14px;
-    padding: 5px;
-    border-bottom: 1px solid #f0f0f0;
 }
 
-.asset-account__history-item:last-child {
-    border-bottom: none;
+.asset-account__history-table th,
+.asset-account__history-table td {
+    border: 1px solid #f0f0f0;
+    padding: 8px;
+    text-align: center;
+}
+
+.asset-account__history-table thead th {
+    background-color: #f9f9f9;
 }
 
 .asset-account__monthly-balances {


### PR DESCRIPTION
## Summary
- render asset account history using a table with separate columns for date, event, and principal values
- style the history table to be full width with collapsed, centered cells that match the tracker layout

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6af8c00832f9dc7b05dfd9d60ab