### PR TITLE
Extract shared account history styles

### DIFF
--- a/apps/asset-tracker/script.js
+++ b/apps/asset-tracker/script.js
@@ -99,11 +99,11 @@ export function setupAssetTracker(sharedData) {
                 </div>
                 <p><strong>Principal:</strong> $${asset.principal.toFixed(2)}</p>
                 <p><strong>Category:</strong> ${asset.category}</p>
-                <div class="asset-account__monthly-balances">
+                <div class="asset-account__monthly-balances account-history__monthly">
                     <h4>Monthly Balances</h4>
-                    <ul class="asset-account__monthly-list">
+                    <ul class="asset-account__monthly-list account-history__monthly-list">
                         ${monthlyBalanceEntries.map(([m, v]) => `
-                            <li class="asset-account__monthly-item">${m}: $${v.toFixed(2)}</li>
+                            <li class="asset-account__monthly-item account-history__monthly-item">${m}: $${v.toFixed(2)}</li>
                         `).join('')}
                     </ul>
                 </div>
@@ -120,11 +120,11 @@ export function setupAssetTracker(sharedData) {
                     <button class="button primary-button save-asset-btn" type="submit">Save</button>
                     <button class="button secondary-button cancel-edit-btn" type="button">Cancel</button>
                 </form>
-                <div class="asset-account__history">
+                <div class="asset-account__history account-history">
                     <h4>Update History</h4>
-                    <ul class="asset-account__history-list">
+                    <ul class="asset-account__history-list account-history__list">
                         ${asset.history.map(entry => `
-                            <li class="asset-account__history-item">
+                            <li class="asset-account__history-item account-history__item">
                                 ${new Date(entry.date).toLocaleDateString()}: ${entry.event} - $${entry.principal.toFixed(2)}
                             </li>
                         `).join('')}

--- a/apps/asset-tracker/style.css
+++ b/apps/asset-tracker/style.css
@@ -1,3 +1,5 @@
+@import url("../../css/account-history.css");
+
 /* Asset Tracker Styles */
 .asset-tracker-header {
     display: flex;
@@ -105,50 +107,5 @@
 
 .asset-account--stale {
     border-left: 5px solid #f44336; /* Red flag for stale accounts */
-}
-
-.asset-account__history {
-    display: none; /* Hidden by default */
-    margin-top: 15px;
-    padding-top: 10px;
-    border-top: 1px solid #eee;
-}
-
-.asset-account__history h4 {
-    margin-bottom: 10px;
-}
-
-.asset-account__history-list {
-    list-style-type: none;
-    padding-left: 0;
-}
-
-.asset-account__history-item {
-    font-size: 14px;
-    padding: 5px;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.asset-account__history-item:last-child {
-    border-bottom: none;
-}
-
-.asset-account__monthly-balances {
-    margin-top: 10px;
-}
-
-.asset-account__monthly-list {
-    list-style-type: none;
-    padding-left: 0;
-    font-size: 12px;
-}
-
-.asset-account__monthly-item {
-    padding: 3px 0;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.asset-account__monthly-item:last-child {
-    border-bottom: none;
 }
 

--- a/apps/debt-tracker/script.js
+++ b/apps/debt-tracker/script.js
@@ -147,9 +147,9 @@ function setupDebtTracker(sharedData) {
                     <div class="debt-account__metric">Yearly Interest: $${metrics.yearlyInterest}</div>
                     <div class="debt-account__metric">Payoff Date: ${metrics.payoffDate}</div>
                 </div>
-                <div class="debt-account__monthly-balances">
+                <div class="debt-account__monthly-balances account-history__monthly">
                     <h4>Monthly Balances</h4>
-                    <table class="debt-account__monthly-table">
+                    <table class="debt-account__monthly-table account-history__monthly-table">
                         <tr>
                             ${monthRange.map(m => `<th>${m}</th>`).join('')}
                         </tr>
@@ -167,11 +167,11 @@ function setupDebtTracker(sharedData) {
                     <button class="button primary-button save-debt-btn" type="submit">Save</button>
                     <button class="button secondary-button cancel-edit-btn" type="button">Cancel</button>
                 </form>
-                <div class="debt-account__history">
+                <div class="debt-account__history account-history">
                     <h4>Update History</h4>
-                    <ul class="debt-account__history-list">
+                    <ul class="debt-account__history-list account-history__list">
                         ${debt.history.map(entry => `
-                            <li class="debt-account__history-item">
+                            <li class="debt-account__history-item account-history__item">
                                 ${new Date(entry.date).toLocaleDateString()}: ${entry.event} - $${entry.principal.toFixed(2)}
                             </li>
                         `).join('')}

--- a/apps/debt-tracker/style.css
+++ b/apps/debt-tracker/style.css
@@ -1,3 +1,5 @@
+@import url("../../css/account-history.css");
+
 /* Debt Tracker Styles */
 .debt-tracker-header {
     display: flex;
@@ -105,63 +107,5 @@
 
 .debt-account--stale {
     border-left: 5px solid #f44336; /* Red flag for stale accounts */
-}
-
-.debt-account__history {
-    display: none; /* Hidden by default */
-    margin-top: 15px;
-    padding-top: 10px;
-    border-top: 1px solid #eee;
-}
-
-.debt-account__history h4 {
-    margin-bottom: 10px;
-}
-
-.debt-account__history-list {
-    list-style-type: none;
-    padding-left: 0;
-}
-
-.debt-account__history-item {
-    font-size: 14px;
-    padding: 5px;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.debt-account__history-item:last-child {
-    border-bottom: none;
-}
-
-.debt-account__monthly-balances {
-    margin-top: 10px;
-}
-
-.debt-account__monthly-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-}
-
-.debt-account__monthly-table th,
-.debt-account__monthly-table td {
-    border: 1px solid var(--border-color);
-    padding: 4px;
-    text-align: center;
-}
-
-.debt-account__monthly-list {
-    list-style-type: none;
-    padding-left: 0;
-    font-size: 12px;
-}
-
-.debt-account__monthly-item {
-    padding: 3px 0;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.debt-account__monthly-item:last-child {
-    border-bottom: none;
 }
 

--- a/css/account-history.css
+++ b/css/account-history.css
@@ -1,0 +1,57 @@
+/* Shared account history styles */
+.account-history {
+    display: none;
+    margin-top: 15px;
+    padding-top: 10px;
+    border-top: 1px solid #eee;
+}
+
+.account-history h4 {
+    margin-bottom: 10px;
+}
+
+.account-history__list,
+.account-history__monthly-list {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.account-history__item {
+    font-size: 14px;
+    padding: 5px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.account-history__item:last-child {
+    border-bottom: none;
+}
+
+.account-history__monthly {
+    margin-top: 10px;
+}
+
+.account-history__monthly-list {
+    font-size: 12px;
+}
+
+.account-history__monthly-item {
+    padding: 3px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.account-history__monthly-item:last-child {
+    border-bottom: none;
+}
+
+.account-history__monthly-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.account-history__monthly-table th,
+.account-history__monthly-table td {
+    border: 1px solid var(--border-color);
+    padding: 4px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a shared css/account-history.css file so both trackers use the same history and monthly balance styling
- update the asset and debt tracker styles to import the shared module and drop their duplicated rules
- attach the shared account-history classes in each tracker script so existing markup renders with the consolidated styles

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6fd3ccc832f91a977a15bd4ac9a