### PR TITLE
Add dark mode styling with theme toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,15 +4,59 @@
     --surface-color: #ffffff;
     --accent-color: #007bff;
     --highlight-color: #e8f0fe;
+    --text-color: #333333;
+    --button-text-color: #000000;
+    --primary-button-text-color: #000000;
+    --shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --border-color: #3d3f49;
+        --bg-color: #10131a;
+        --surface-color: #1b1f29;
+        --accent-color: #4dabf7;
+        --highlight-color: #2b354b;
+        --text-color: #f5f7fb;
+        --button-text-color: #f5f7fb;
+        --primary-button-text-color: #f5f7fb;
+        --shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+    }
+}
+
+body.theme-dark {
+    color-scheme: dark;
+    --border-color: #3d3f49;
+    --bg-color: #10131a;
+    --surface-color: #1b1f29;
+    --accent-color: #4dabf7;
+    --highlight-color: #2b354b;
+    --text-color: #f5f7fb;
+    --button-text-color: #f5f7fb;
+    --primary-button-text-color: #f5f7fb;
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+}
+
+body.theme-light {
+    color-scheme: light;
+    --border-color: #ddd;
+    --bg-color: #fafafa;
+    --surface-color: #ffffff;
+    --accent-color: #007bff;
+    --highlight-color: #e8f0fe;
+    --text-color: #333333;
+    --button-text-color: #000000;
+    --primary-button-text-color: #000000;
     --shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: var(--bg-color);
-    color: #333;
+    color: var(--text-color);
     margin: 0;
     padding: 20px;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .header {
@@ -25,6 +69,21 @@ body {
     text-align: center;
     border-radius: 8px;
     box-shadow: var(--shadow);
+    position: relative;
+}
+
+.theme-toggle {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+}
+
+@media (max-width: 600px) {
+    .theme-toggle {
+        position: static;
+        display: block;
+        margin: 12px auto 0;
+    }
 }
 
 .app-container {
@@ -57,6 +116,7 @@ body {
 .toggle-add-form-btn {
     background: var(--highlight-color);
     border: 1px solid var(--border-color);
+    color: var(--button-text-color);
     cursor: pointer;
     transition: background-color 0.2s;
     border-radius: 4px;
@@ -143,7 +203,7 @@ body {
     border: 1px solid var(--border-color);
     border-radius: 4px;
     background: var(--surface-color);
-    color: #000;
+    color: var(--button-text-color);
     cursor: pointer;
     font-size: 16px;
     text-align: center;
@@ -161,7 +221,7 @@ body {
 
 .primary-button {
     background-color: var(--highlight-color);
-    color: #000;
+    color: var(--primary-button-text-color);
 }
 
 .primary-button:hover {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
 
-    <div class="header">Finance Apps</div>
+    <div class="header">
+        Finance Apps
+        <button id="theme-toggle" class="button theme-toggle" type="button" aria-pressed="false">Toggle theme</button>
+    </div>
 
     <div class="app-container" id="app-container">
         <!-- Tiles will be dynamically generated here -->

--- a/js/script.js
+++ b/js/script.js
@@ -190,4 +190,65 @@ document.addEventListener('DOMContentLoaded', () => {
             closeModal();
         }
     });
+
+    const themeStorageKey = 'preferredTheme';
+    const themeToggle = document.getElementById('theme-toggle');
+    const validTheme = (theme) => theme === 'light' || theme === 'dark';
+
+    const applyTheme = (theme) => {
+        document.body.classList.remove('theme-light', 'theme-dark');
+        if (validTheme(theme)) {
+            document.body.classList.add(`theme-${theme}`);
+        }
+    };
+
+    const systemPrefersDark = () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const getActiveTheme = () => {
+        if (document.body.classList.contains('theme-dark')) {
+            return 'dark';
+        }
+        if (document.body.classList.contains('theme-light')) {
+            return 'light';
+        }
+        return systemPrefersDark() ? 'dark' : 'light';
+    };
+
+    const updateToggleLabel = () => {
+        if (!themeToggle) {
+            return;
+        }
+        const activeTheme = getActiveTheme();
+        const nextTheme = activeTheme === 'dark' ? 'light' : 'dark';
+        themeToggle.textContent = nextTheme === 'dark' ? 'Switch to Dark Mode' : 'Switch to Light Mode';
+        themeToggle.setAttribute('aria-pressed', activeTheme === 'dark' ? 'true' : 'false');
+    };
+
+    const storedTheme = loadJSON(themeStorageKey, null);
+    if (validTheme(storedTheme)) {
+        applyTheme(storedTheme);
+    }
+
+    if (themeToggle) {
+        updateToggleLabel();
+        themeToggle.addEventListener('click', () => {
+            const activeTheme = getActiveTheme();
+            const nextTheme = activeTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(nextTheme);
+            saveJSON(themeStorageKey, nextTheme);
+            updateToggleLabel();
+        });
+    }
+
+    if (!validTheme(storedTheme) && window.matchMedia) {
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const handleChange = () => {
+            updateToggleLabel();
+        };
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', handleChange);
+        } else if (typeof mediaQuery.addListener === 'function') {
+            mediaQuery.addListener(handleChange);
+        }
+    }
 });


### PR DESCRIPTION
## Summary
- add a dark color palette via CSS variables and adapt layout elements to consume them
- introduce a header theme toggle that persists the user choice and responds to system preferences

## Testing
- not run (no package.json present)


------
https://chatgpt.com/codex/tasks/task_e_68c8b6ffd950832f8dc4fde79e56d4cd