### PR TITLE
Improve asset history view and add resizable cards

### DIFF
--- a/apps/asset-tracker/style.css
+++ b/apps/asset-tracker/style.css
@@ -35,6 +35,9 @@
     border-radius: 4px;
     padding: 15px;
     margin-bottom: 15px;
+    resize: vertical;
+    overflow: auto;
+    min-height: 180px;
 }
 
 .asset-account__header {
@@ -52,6 +55,21 @@
     border: 1px solid var(--border-color);
     cursor: pointer;
     border-radius: 4px;
+}
+
+.asset-account__header-actions .toggle-history-btn[aria-expanded="true"] {
+    background-color: var(--highlight-color);
+    color: var(--primary-button-text-color);
+}
+
+.asset-account__empty-state {
+    font-size: 13px;
+    color: #555;
+    margin: 5px 0 0;
+}
+
+.asset-account__monthly-balances table {
+    margin-top: 8px;
 }
 
 .asset-account__name {

--- a/css/account-history.css
+++ b/css/account-history.css
@@ -55,3 +55,14 @@
     padding: 4px;
     text-align: center;
 }
+
+.account-history__monthly-table th:first-child,
+.account-history__monthly-table td:first-child {
+    text-align: left;
+}
+
+.account-history__monthly-table th:last-child,
+.account-history__monthly-table td:last-child {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary
- render asset monthly history as a structured table with formatted months and reusable currency formatting
- add a dedicated history toggle and styling updates to keep history interactions predictable
- allow asset cards to be resized and refine monthly table styling for readability

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8baf38de8832fa51a416fc59b3269